### PR TITLE
Fix RPCS3 - NURL update

### DIFF
--- a/nix/Dockerfile
+++ b/nix/Dockerfile
@@ -39,11 +39,16 @@ COPY ./*.nix .
 COPY ./*.patch .
 COPY ./emulators-src.json .
 RUN . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && \
+nix-channel --add https://nixos.org/channels/nixpkgs-unstable unstable && \
 nix-channel --update && \
 ./localbuild.sh && \
-nix-build dolphin.nix flycast.nix pcsx2.nix && \
-nix-build rmg.nix rpcs3.nix && \
-nix-build xemu.nix xenia-canary.nix && \
+nix-build dolphin.nix && \
+nix-build flycast.nix && \
+nix-build pcsx2.nix && \
+nix-build rmg.nix && \
+NIXPKGS_ALLOW_UNFREE=1 nix-build rpcs3.nix && \
+nix-build xemu.nix && \
+nix-build xenia-canary.nix && \
 nix-build eden.nix && \
 # #RUN . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && \
 nix-env -i -f ./eden.nix && \

--- a/nix/Dockerfile
+++ b/nix/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
-LABEL org.opencontainers.image.source https://github.com/T2theV/Cumulus-Emulation-Project
+LABEL org.opencontainers.image.source=https://github.com/T2theV/Cumulus-Emulation-Project
 
 RUN apt update && apt install -y --no-install-recommends \
 #  build-essential clang-format git cmake gettext libharfbuzz-dev libicu-dev libsdl2-dev libavcodec-dev libavfilter-dev libavformat-dev libavutil-dev libfreeimage-dev libfreetype6-dev libgit2-dev libcurl4-openssl-dev libpugixml-dev libasound2-dev libbluetooth-dev libgl1-mesa-dev libpoppler-cpp-dev \

--- a/nix/Dockerfile
+++ b/nix/Dockerfile
@@ -56,7 +56,7 @@ nix-env -i -f ./dolphin.nix && \
 nix-env -i -f ./flycast.nix && \
 nix-env -i -f ./pcsx2.nix && \
 nix-env -i -f ./rmg.nix && \
-nix-env -i -f ./rpcs3.nix && \
+NIXPKGS_ALLOW_UNFREE=1 nix-env -i -f ./rpcs3.nix && \
 nix-env -i -f ./xemu.nix && \
 nix-env -i -f ./xenia-canary.nix && \
 nix-store --gc

--- a/nix/prefetch.sh
+++ b/nix/prefetch.sh
@@ -11,6 +11,6 @@
 # nurl -e '(import <nixpkgs> { }).xemu.src.overrideAttrs(_:{tag=0; rev="5aeacacfeb7a28ad7d5a9ecab9978115804148dc";})' > xemu.hash &
 # nurl -e '(import <nixpkgs> { }).xenia-canary.src.overrideAttrs(_:{tag=0; rev="bc69b95db698efdcb4dcf36101b9c252d28f0c95";})' > xenia.hash &
 
-HASH=$(nurl -e "(import <nixpkgs> { overlays= [(import ./"${1}"-overlay.nix)]; })."${1}".src")
+HASH=$(nurl -e "(import (fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-unstable") { overlays= [(import ./"${1}"-overlay.nix)]; })."${1}".src")
 
 jq --arg substitute $HASH '. += { "hash" : $substitute }' ${1}-out.json > ${1}-full-out.json

--- a/nix/rpcs3.nix
+++ b/nix/rpcs3.nix
@@ -11,6 +11,10 @@ rec{
   rpcs3-new = pkgs.rpcs3.overrideAttrs (finalAttrs: previousAttrs: {
       version = "master";
       src = rpcs3-src;
+      buildInputs = previousAttrs.buildInputs ++ [ 
+	pkgs.jack2
+	pkgs.alsa-lib
+      ];
   });
 
 }


### PR DESCRIPTION
Nurl would prefetch the wrong nix package in the determinate systems channel. Changed the nurl expression to look at unstable.